### PR TITLE
Fix redis_sentinel password usage

### DIFF
--- a/backends/redis-sentinel.go
+++ b/backends/redis-sentinel.go
@@ -46,10 +46,11 @@ type RedisSentinelBackend struct {
 // NewRedisSentinelBackend initializes the Redis Sentinel client and pings to make sure connection was successful
 func NewRedisSentinelBackend(cfg config.RedisSentinel, ctx context.Context) *RedisSentinelBackend {
 	options := &redis.FailoverOptions{
-		MasterName:    cfg.MasterName,
-		SentinelAddrs: cfg.SentinelAddrs,
-		Password:      cfg.Password,
-		DB:            cfg.Db,
+		MasterName:       cfg.MasterName,
+		SentinelAddrs:    cfg.SentinelAddrs,
+		SentinelPassword: cfg.Password,
+		Password:         cfg.Password,
+		DB:               cfg.Db,
 	}
 
 	if cfg.TLS.Enabled {


### PR DESCRIPTION
When using a password in Redis Sentinel, it should be provided at both levels